### PR TITLE
Conda Packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 .sconsign.dblite
 config.log
 .sconf_temp

--- a/Jenkinsfile.conda
+++ b/Jenkinsfile.conda
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 script {
                     sh """
-                    docker run --name ${container_name} -di --rm --env TS_XML_VERSION=v${xml_version} --env IDL_VERION=${idl_version} \
+                    docker run --name ${container_name} -di --rm --env TS_XML_VERSION=v${xml_version} --env IDL_VERSION=${idl_version} \
                         -v ${WORKSPACE}/conda:/home/saluser/conda ${dockerImageName}
                     docker exec -u root -w /tmp ${container_name} sh -c "repoquery --disablerepo="*" --enablerepo="lsst-ts" -a \
                         |grep -v _test- |grep -v python-0 |grep -v OpenSplice |xargs yum install -y"

--- a/Jenkinsfile.conda
+++ b/Jenkinsfile.conda
@@ -21,10 +21,11 @@ pipeline {
             steps {
                 script {
                     sh """
-                    docker run --name ${container_name} -di --rm -v ${WORKSPACE}/conda:/home/saluser/conda ${dockerImageName}
+                    docker run --name ${container_name} -di --rm --env TS_XML_VERSION=v${xml_version} --env IDL_VERION=${idl_version} \
+                        -v ${WORKSPACE}/conda:/home/saluser/conda ${dockerImageName}
                     docker exec -u root -w /tmp ${container_name} sh -c "repoquery --disablerepo="*" --enablerepo="lsst-ts" -a \
                         |grep -v _test- |grep -v python-0 |grep -v OpenSplice |xargs yum install -y"
-                    docker exec --env TS_XML_VERSION=v${xml_version} ${container_name} sh -c "cd ~/conda && source ~/miniconda3/bin/activate && conda build ."
+                    docker exec ${container_name} sh -c "cd ~/conda && source ~/miniconda3/bin/activate && conda build ."
                     docker exec ${container_name} sh -c "ls ~/miniconda3/conda-bld/linux-64"
                     """
                 }
@@ -38,7 +39,7 @@ pipeline {
                         docker exec ${container_name} sh -c "source ~/miniconda3/bin/activate && \
                             anaconda login --user ${anaconda_user} --password ${anaconda_pass} && \
                             anaconda upload -u lsstts --force \
-                            ~/miniconda3/conda-bld/linux-64/ts-idl-${idl_version}_v${xml_version}-py37_0.tar.bz2"
+                            ~/miniconda3/conda-bld/linux-64/ts-idl-${idl_version}_${xml_version}-py37_0.tar.bz2"
                         """
                     }
                 }

--- a/Jenkinsfile.conda
+++ b/Jenkinsfile.conda
@@ -1,0 +1,55 @@
+pipeline {
+    agent any
+    environment {
+        idl_version = "${GIT_TAG_NAME}"
+        xml_version = "4.6.0"
+        dockerImageName = "lsstts/conda_package_builder:latest"
+        container_name = "idl_${BUILD_ID}_${JENKINS_NODE_COOKIE}"
+    }
+
+    stages {
+        stage("Pull Docker Image") {
+            steps {
+                script {
+                    sh """
+                    docker pull ${dockerImageName}
+                    """
+                }
+            }
+        }
+        stage("Create IDL Conda package") {
+            steps {
+                script {
+                    sh """
+                    docker run --name ${container_name} -di --rm -v ${WORKSPACE}/conda:/home/saluser/conda ${dockerImageName}
+                    docker exec -u root -w /tmp ${container_name} sh -c "repoquery --disablerepo="*" --enablerepo="lsst-ts" -a \
+                        |grep -v _test- |grep -v python-0 |grep -v OpenSplice |xargs yum install -y"
+                    docker exec --env TS_XML_VERSION=v${xml_version} ${container_name} sh -c "cd ~/conda && source ~/miniconda3/bin/activate && conda build ."
+                    docker exec ${container_name} sh -c "ls ~/miniconda3/conda-bld/linux-64"
+                    """
+                }
+            }
+        }
+        stage("Push IDL Conda package") {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'CondaForge', passwordVariable: 'anaconda_pass', usernameVariable: 'anaconda_user')]) {
+                    script {
+                        sh """
+                        docker exec ${container_name} sh -c "source ~/miniconda3/bin/activate && \
+                            anaconda login --user ${anaconda_user} --password ${anaconda_pass} && \
+                            anaconda upload -u lsstts --force \
+                            ~/miniconda3/conda-bld/linux-64/ts-idl-${idl_version}_v${xml_version}-py37_0.tar.bz2"
+                        """
+                    }
+                }
+            }
+        }
+    }
+    post {
+        cleanup {
+            sh """
+            docker stop ${container_name}
+            """
+        }
+    }
+}

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,5 @@
+pip install -e .
+
+python setup.py sdist
+cd dist
+pip install *.tar.gz

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,5 +1,7 @@
 pip install -e .
 
+cp -v /opt/lsst/ts_sal/idl/*idl `python -c 'from lsst.ts import idl; print(idl.get_idl_dir())'`
+
 python setup.py sdist
 cd dist
 pip install *.tar.gz

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,31 @@
+{% set data= load_setup_py_data() %}
+package:
+  name: ts-idl
+  version: {{ data.get('version') }}_{{ TS_XML_VERSION }}
+
+source:
+  git_url: https://github.com/lsst-ts/ts_idl
+  git_rev: v1.1.0
+
+build:
+  skip: False #[win]
+  script_env:
+    - PATH
+    - PYTHONPATH
+    - LD_LIBRARY_PATH
+    - LSST_SDK_INSTALL
+    - OSPL_HOME
+    - LSST_DDS_DOMAIN
+    - PYTHON_BUILD_VERSION
+    - PYTHON_BUILD_LOCATION
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools_scm
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - setuptools_scm

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -5,7 +5,7 @@ package:
 
 source:
   git_url: https://github.com/lsst-ts/ts_idl
-  git_rev: {{ idl_version }}
+  git_rev: {{ IDL_VERSION }}
 
 build:
   skip: False #[win]

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -5,7 +5,7 @@ package:
 
 source:
   git_url: https://github.com/lsst-ts/ts_idl
-  git_rev: v1.1.0
+  git_rev: {{ idl_version }}
 
 build:
   skip: False #[win]


### PR DESCRIPTION
* Adding the infrastructure needed to create the IDL conda package. 
* No longer checking out ts_recipes and building the agent container.  Now pulling down the image from lsstts Docker Hub.
* Added installation of latest CSC RPMs from Nexus3 yum repo.
* Removed steps in conda/build.sh since we are no longer building the RPMs at runtime, but are now pulling them from the yum repo.
* Added *.swp files to .gitignore.